### PR TITLE
Add files via upload

### DIFF
--- a/scripts/options.js
+++ b/scripts/options.js
@@ -55,6 +55,7 @@ loc.addEventListener("change", (event) => {
 	
 	getLocationMatch(event.currentTarget.value).then((matchedAddress) => {
 		matchAddr.textContent = `Matched: ${matchedAddress}`;
+		chrome.storage.session.set({"overrideRefreshTimer": true});
 	});
 });
 


### PR DESCRIPTION
Now allowing the user to override the refresh timer if they change the region quickly after opening the popup. Still has rate-limit prevention, stopping them from doing it more than once per 10 seconds.